### PR TITLE
Fix add_expense() under SQLAlchemy 2.0, drop dead envfile references

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ services:
     ksiemgowyd:
         build:
             context: .
-        env_file:
-            - envfile_secret
-            - envfile_public
         environment:
             DEPLOY_KEY_PATH: /run/secrets/deploy_key
         volumes:

--- a/ksiemgowy/models.py
+++ b/ksiemgowy/models.py
@@ -195,7 +195,7 @@ class KsiemgowyDB:
         bank_action.amount_pln *= -1
         with self.connection.begin():
             self.connection.execute(
-                self.bank_actions.insert(), **bank_action.asdict()
+                self.bank_actions.insert(), bank_action.asdict()
             )
 
     def list_expenses(self) -> Iterator[MbankAction]:

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,0 +1,45 @@
+import unittest
+
+import ksiemgowy.models
+
+from ksiemgowy.mbankmail import MbankAction
+
+
+def build_action(action_type, amount_pln=10.0):
+    return MbankAction(
+        sender_acc_no="sender",
+        recipient_acc_no="recipient",
+        amount_pln=amount_pln,
+        in_person="person",
+        in_desc="desc",
+        balance=1000.0,
+        timestamp="2026-07-30 12:00:00",
+        action_type=action_type,
+    )
+
+
+class KsiemgowyDBTestCase(unittest.TestCase):
+    def setUp(self):
+        self.database = ksiemgowy.models.KsiemgowyDB("sqlite://")
+
+    def test_add_expense_stores_a_listable_expense(self):
+        """add_expense() splats the action into Connection.execute() as
+        keyword arguments, which SQLAlchemy 2.0 rejects. Every outgoing
+        transfer therefore blows up check_for_updates()."""
+        self.database.add_expense(build_action("out_transfer"))
+
+        expenses = list(self.database.list_expenses())
+
+        self.assertEqual(len(expenses), 1)
+        self.assertEqual(expenses[0].amount_pln, 10.0)
+        self.assertEqual(expenses[0].recipient_acc_no, "recipient")
+        self.assertEqual(expenses[0].action_type, "out_transfer")
+
+    def test_expenses_are_not_reported_as_positive_transfers(self):
+        """Expenses are stored negated, so they must not leak into the
+        positive transfer listing (and vice versa)."""
+        self.database.add_expense(build_action("out_transfer"))
+        self.database.add_positive_transfer(build_action("in_transfer"))
+
+        self.assertEqual(len(list(self.database.list_expenses())), 1)
+        self.assertEqual(len(list(self.database.list_positive_transfers())), 1)


### PR DESCRIPTION
Two independent breakages that a `git pull && git checkout master` on a
long-running deployment walks straight into.

## 1. `add_expense()` raises on every outgoing transfer

`models.py` splatted the action into `Connection.execute()` as keyword
arguments. SQLAlchemy 2.0 takes bound parameters as a single positional
mapping, so:

```
TypeError: Connection.execute() got an unexpected keyword argument 'sender_acc_no'
```

`add_positive_transfer()` directly above already passed the mapping
positionally — this makes `add_expense()` match.

It is worse than a lost expense. The exception propagates out of
`check_for_updates()`, which `__main__.main()` calls **synchronously at
startup**, so a single `out_transfer` sitting in the mailbox stops
ksiemgowy from booting at all. And because `gen_unseen_mbank_emails()`
only marks a message handled *after* the `yield`, that message is never
recorded as seen — every restart replays it. One outgoing transfer is
enough to produce a permanent boot loop.

This survived the SQLAlchemy 2.0 port (9ddfa60) because `add_expense()`
was the one write path in `KsiemgowyDB` with no test coverage. The first
commit here adds that test and fails; the second turns it green.

## 2. `envfile_secret` / `envfile_public` no longer exist as a concept

Nothing has read them since configuration moved into `config.yaml` —
ab2385e migrated most of it and 37773a1 finished the job by moving
`MBANK_ANONYMIZATION_KEY` and `DEPLOY_KEY_PATH` over. The only
environment variable the code reads today is `KSIEMGOWYD_CFG_FILE`, and
it has a default.

They were not just noise: compose refuses to do anything when a declared
`env_file` is missing, so on a host that never had those files even
validation fails.

```
$ docker compose config          # before
env file /.../envfile_secret not found
$ docker compose config          # after
<renders fine>
```

## Verification

- `python -m unittest` — 13/13 green (11 before, +2 new)
- `docker compose config` — succeeds; fails on master
- `flake8 --ignore=W503 ksiemgowy/` — reports the same 4 pre-existing
  E501s before and after; this PR neither adds nor fixes them

## Deliberately left out

- The 4 pre-existing `E501`s, introduced by the `s/in_acc_no/…` and
  `s/out_acc_no/…` sed commits, currently leave the flake8 job red on
  master. A blanket `black -l 79` run fixes them but does not belong in a
  bugfix PR — happy to send it separately.
- `environment: DEPLOY_KEY_PATH` in docker-compose.yml is dead as well
  (`config.py` reads `DEPLOY_KEY_PATH` from the YAML), but removing it
  needs the path moved into `config.yaml` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)