### PR TITLE
Stop list_expenses() from leaking an uncommitted transaction

### DIFF
--- a/ksiemgowy/models.py
+++ b/ksiemgowy/models.py
@@ -5,7 +5,8 @@
 
 import logging
 import datetime
-from typing import Dict, Iterator, Optional
+import inspect
+from typing import Dict, List, Optional
 from functools import wraps
 import typing as T
 
@@ -25,7 +26,19 @@ def transactional(method: T.Callable[..., T.Any]) -> T.Callable[..., T.Any]:
 
     I mostly wrote it to avoid extra indentation in the code that complicates
     merging and reading the diffs. Ideally I think we should factor it in.
+
+    Generator functions are rejected outright. Calling one merely builds the
+    generator without running a line of its body, so the transaction would
+    open and close before a single row is read, and the body would then
+    autobegin one that nobody ever commits - poisoning the connection for
+    every later caller. Materialise the rows and return a list instead.
     """
+    if inspect.isgeneratorfunction(method):
+        raise TypeError(
+            f"@transactional cannot wrap the generator function "
+            f"{method.__qualname__}; return a list instead"
+        )
+
     @wraps(method)
     def wrapper(self: T.Any, *args: T.Any, **kwargs: T.Any) -> T.Any:
         with self.connection.begin():
@@ -194,18 +207,19 @@ class KsiemgowyDB:
             .values(notify_overdue_no_earlier_than=new_date)
         )
 
-    def list_positive_transfers(self) -> Iterator[MbankAction]:
-        """Returns a generator that lists all positive transfers that were
-        observed so far."""
-
-        with self.connection.begin():
-            for entry in self.connection.execute(
-                self.bank_actions.select().where(
-                    self.bank_actions.c.action_type == "in_transfer"
-                )
-            ).mappings():
-                entry = {k: v for k, v in dict(entry).items() if k != "id"}
-                yield ksiemgowy.mbankmail.MbankAction(**entry)
+    @transactional
+    def list_positive_transfers(self) -> List[MbankAction]:
+        """Returns a list of all positive transfers that were observed so
+        far."""
+        ret = []
+        for entry in self.connection.execute(
+            self.bank_actions.select().where(
+                self.bank_actions.c.action_type == "in_transfer"
+            )
+        ).mappings():
+            entry = {k: v for k, v in dict(entry).items() if k != "id"}
+            ret.append(ksiemgowy.mbankmail.MbankAction(**entry))
+        return ret
 
     def add_positive_transfer(self, positive_action: MbankAction) -> None:
         """Adds a positive transfer to the database."""
@@ -230,9 +244,10 @@ class KsiemgowyDB:
             )
 
     @transactional
-    def list_expenses(self) -> Iterator[MbankAction]:
-        """Returns a generator that lists all expenses transfers that were
-        observed so far."""
+    def list_expenses(self) -> List[MbankAction]:
+        """Returns a list of all expenses transfers that were observed so
+        far."""
+        ret = []
         for entry in self.connection.execute(
             self.bank_actions.select().where(
                 self.bank_actions.c.amount_pln < 0
@@ -241,4 +256,5 @@ class KsiemgowyDB:
             entry = {k: v for k, v in dict(entry).items() if k != "id"}
             bank_action = ksiemgowy.mbankmail.MbankAction(**entry)
             bank_action.amount_pln *= -1
-            yield bank_action
+            ret.append(bank_action)
+        return ret

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,0 +1,80 @@
+import unittest
+
+import ksiemgowy.models
+
+from ksiemgowy.mbankmail import MbankAction
+from ksiemgowy.models import transactional
+
+
+def build_action(action_type, amount_pln=10.0):
+    return MbankAction(
+        recipient_acc_no="recipient",
+        sender_acc_no="sender",
+        amount_pln=amount_pln,
+        in_person="person",
+        in_desc="desc",
+        balance=1000.0,
+        timestamp="2026-07-30 12:00:00",
+        action_type=action_type,
+    )
+
+
+class TransactionalTestCase(unittest.TestCase):
+    def test_refuses_to_wrap_a_generator_function(self):
+        """Wrapping a generator function is always a mistake: calling it only
+        builds the generator, so the transaction opens and closes before a
+        single row is read. Fail at decoration time rather than leaking a
+        transaction at runtime."""
+
+        with self.assertRaises(TypeError):
+
+            @transactional
+            def a_generator(self):  # pylint: disable=unused-argument
+                yield 1
+
+
+class KsiemgowyDBTransactionTestCase(unittest.TestCase):
+    def setUp(self):
+        self.database = ksiemgowy.models.KsiemgowyDB("sqlite://")
+        self.database.add_positive_transfer(build_action("in_transfer"))
+
+    def test_listing_expenses_leaves_no_transaction_behind(self):
+        """list_expenses() used to autobegin a transaction that nobody ever
+        committed, poisoning the connection for every later caller."""
+        list(self.database.list_expenses())
+
+        self.assertFalse(self.database.connection.in_transaction())
+
+    def test_listing_positive_transfers_leaves_no_transaction_behind(self):
+        list(self.database.list_positive_transfers())
+
+        self.assertFalse(self.database.connection.in_transaction())
+
+    def test_expenses_then_positive_transfers(self):
+        """Regression test for the exact ordering get_expected_balance_before()
+        uses. It raised:
+
+            InvalidRequestError: This connection has already initialized a
+            SQLAlchemy Transaction() object via begin() or autobegin; can't
+            call begin() here unless rollback() or commit() is called first.
+        """
+        list(self.database.list_expenses())
+        positive_transfers = list(self.database.list_positive_transfers())
+
+        self.assertEqual(len(positive_transfers), 1)
+
+    def test_positive_transfers_then_expenses(self):
+        """The order homepage_updater.maybe_update_dues() uses."""
+        list(self.database.list_positive_transfers())
+        expenses = list(self.database.list_expenses())
+
+        self.assertEqual(expenses, [])
+
+    def test_listings_can_be_interleaved(self):
+        """Both listings materialise before returning, so holding on to one
+        while consuming the other must not matter."""
+        expenses = self.database.list_expenses()
+        positive_transfers = self.database.list_positive_transfers()
+
+        self.assertEqual(list(expenses), [])
+        self.assertEqual(len(list(positive_transfers)), 1)


### PR DESCRIPTION
`ksiemgowyd` dies on the first notification e-mail that triggers an
autocorrection, and `restart: unless-stopped` turns that into a restart
loop:

```
File "/ksiemgowy/bookkeeping.py", line 201, in maybe_apply_autocorrections
    expected_balance = get_expected_balance_before(
File "/ksiemgowy/bookkeeping.py", line 136, in get_expected_balance_before
    for action in database.list_positive_transfers():
File "/ksiemgowy/models.py", line 201, in list_positive_transfers
    with self.connection.begin():
sqlalchemy.exc.InvalidRequestError: This connection has already initialized
a SQLAlchemy Transaction() object via begin() or autobegin; can't call
begin() here unless rollback() or commit() is called first.
```

## Root cause

`@transactional` cannot wrap a generator function, and `list_expenses()`
is one. Calling a generator function only builds the generator object
without running a line of its body, so the decorator's

```python
with self.connection.begin():
    result = method(self, *args, **kwargs)
```

opened and closed an *empty* transaction. The body then ran later, during
iteration, with no transaction in scope — and SQLAlchemy 2.0 autobegins
one there that nobody ever commits. From that point the connection is
poisoned for every later caller.

`get_expected_balance_before()` hits exactly that ordering: it drains
`list_expenses()` (leaks), then calls `list_positive_transfers()`, whose
explicit `begin()` raises.

Reproduced directly against the shipped code:

```
list_expenses is a generator function?  True
transaction open at start?             False
transaction open after list_expenses?  True   <-- leaked
list_positive_transfers()              InvalidRequestError
```

20e9324 treated the same underlying defect at one call site, by wrapping
`maybe_update_dues()`'s two listings in `list()`. That helped there, but
left `bookkeeping.py:129` and `overdues.py:76` exposed and did not stop
`list_expenses()` from leaking the transaction in the first place.

## Fix

Both listings now materialise their rows inside a single transaction and
return a `List[MbankAction]`. Every caller either iterates the result or
already wraps it in `list()`, so nothing else changes.

`@transactional` now raises `TypeError` at decoration time when handed a
generator function, so this cannot be re-introduced silently.

## Verification

- `python -m unittest` — 17 tests, 16 green. The one error,
  `test_homepage_updater` → `KeyError: 'by_period'`, reproduces
  identically on unmodified `autocorrect_based_on_reported_balance`; it
  is pre-existing and untouched here.
- `flake8 --ignore=W503 ksiemgowy/` — clean
- `pylint ksiemgowy/` — 10.00/10
- `mypy --strict ksiemgowy` — same 4 errors before and after, at shifted
  line numbers (207→220, 241→256). Not introduced by this PR, but worth
  knowing the mypy job is red on this branch independently.

The first commit adds the tests and fails; the second turns them green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)